### PR TITLE
Use iipc-web-commons consistently as the project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-OpenWayback Web Commons
+IIPC Web Commons
 =======================
 
 [![Build Status](https://travis-ci.org/iipc/iipc-web-commons.png?branch=master)](https://travis-ci.org/iipc/iipc-web-commons/)
 
-This repository contains common utility code for the [OpenWayback][1] project.
+This repository contains common utility code for [OpenWayback][1] and other projects.
 
 [1]: https://github.com/iipc/openwayback

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 
   <groupId>org.netpreserve.commons</groupId>
-  <artifactId>commons-web</artifactId>
+  <artifactId>iipc-web-commons</artifactId>
   <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
This project should be named consistently. If the github repository is called "iipc-web-commons", it can only cause confusion to make the artifact name "commons-web", since that will be the name of the distribution jar and/or tar.gz. Having a third name, "OpenWayback Web Commons", in the readme, is even more confusing. 

The most important thing, imho, is that the names be consistent. So if it has to be "commons-web", let's make it commons-web everywhere. Likewise if it has to be "OpenWayback Web Commons". But I think "iipc-web-commons" is the most appropriate name.

"commons-web" doesn't make sense to me in English, "web-commons" does. The only reason to reverse that ordering is if it's a subproject of something called "commons". And "commons-web" invites confusion with the http://commons.apache.org/ subprojects. Also commons-web is very generic sounding, it could be a lot of things, so I think qualifying it with "iipc" is appropriate.

I don't particularly like "OpenWayback Web Commons" either, because the library is used for more than just openwayback.

But the most important thing in my mind is that the names be consistent.

Edit: I just noticed that if you do a maven build currently, you end up with two jars, "commons-web-1.1.1-SNAPSHOT.jar" and "iipc-web-commons-jar-with-dependencies.jar"!
