### PR TITLE
Change hadoop libs to "provided" so other hadoop libs can be used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-core</artifactId>
       <version>0.20.2-cdh3u4</version>
+	  <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
(i.e. the ones provided on the cluster) - I can now use this on my CDH4 cluster
(via ukwa/webarchive-discovery/warc-hadoop-recordreaders 2.0-dev branch)

Ref Issue #15
