### PR TITLE
Fix for issue #21

### DIFF
--- a/src/main/java/org/archive/format/gzip/zipnum/ZipNumCluster.java
+++ b/src/main/java/org/archive/format/gzip/zipnum/ZipNumCluster.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -102,7 +103,7 @@ public class ZipNumCluster extends ZipNumIndex {
 	public final static String LATEST_TIMESTAMP = "_LATEST";	
 	public final static String OFF = "OFF";
 	
-	protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+	protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
 	protected Date startDate, endDate;
 	
 	class BlockSize

--- a/src/main/java/org/archive/util/ArchiveUtils.java
+++ b/src/main/java/org/archive/util/ArchiveUtils.java
@@ -104,7 +104,7 @@ public class ArchiveUtils {
     private static ThreadLocal<SimpleDateFormat> threadLocalDateFormat(final String pattern) {
         ThreadLocal<SimpleDateFormat> tl = new ThreadLocal<SimpleDateFormat>() {
             protected SimpleDateFormat initialValue() {
-                SimpleDateFormat df = new SimpleDateFormat(pattern);
+                SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ENGLISH);
                 df.setTimeZone(TimeZone.getTimeZone("GMT"));
                 return df;
             }
@@ -393,9 +393,9 @@ public class ArchiveUtils {
     }
     
     final static SimpleDateFormat dateToTimestampFormats[] = 
-          {new SimpleDateFormat("MM/dd/yyyy"), 
-		   new SimpleDateFormat("MM/yyyy"), 
-		   new SimpleDateFormat("yyyy")};
+          {new SimpleDateFormat("MM/dd/yyyy", Locale.ENGLISH),
+		   new SimpleDateFormat("MM/yyyy", Locale.ENGLISH),
+		   new SimpleDateFormat("yyyy", Locale.ENGLISH)};
 
     /**
      * Convert a user-entered date into a timestamp

--- a/src/main/java/org/archive/util/DateUtils.java
+++ b/src/main/java/org/archive/util/DateUtils.java
@@ -65,7 +65,7 @@ public class DateUtils {
     private static ThreadLocal<SimpleDateFormat> threadLocalDateFormat(final String pattern) {
         ThreadLocal<SimpleDateFormat> tl = new ThreadLocal<SimpleDateFormat>() {
             protected SimpleDateFormat initialValue() {
-                SimpleDateFormat df = new SimpleDateFormat(pattern);
+                SimpleDateFormat df = new SimpleDateFormat(pattern, Locale.ENGLISH);
                 df.setTimeZone(TimeZone.getTimeZone("GMT"));
                 return df;
             }

--- a/src/main/java/org/archive/util/binsearch/impl/http/ApacheHttp31SLRFactory.java
+++ b/src/main/java/org/archive/util/binsearch/impl/http/ApacheHttp31SLRFactory.java
@@ -3,6 +3,7 @@ package org.archive.util.binsearch.impl.http;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
@@ -156,7 +157,7 @@ public class ApacheHttp31SLRFactory extends HTTPSeekableLineReaderFactory {
 	public long getModTime()
 	{
 		HTTPSeekableLineReader reader = null;
-		SimpleDateFormat lastModFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+		SimpleDateFormat lastModFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
 	
 		try {
 			reader = get();


### PR DESCRIPTION
This change will force dates to always be in the english locale. Applying this code will break one unit test in OpenWayback on machines with non-english locale because the test itself is not locale-safe.

Fixes https://github.com/iipc/webarchive-commons/issues/21
