### PR TITLE
Correct WARC writer concerning missing CRLF in records with zero payload...

### DIFF
--- a/src/main/java/org/archive/io/warc/WARCWriter.java
+++ b/src/main/java/org/archive/io/warc/WARCWriter.java
@@ -245,10 +245,11 @@ implements WARCConstants {
             write(bytes);
             totalBytes += bytes.length;
 
+            // Write out the header/body separator.
+            write(CRLF_BYTES);
+            totalBytes += CRLF_BYTES.length;
+
             if (recordInfo.getContentStream() != null && recordInfo.getContentLength() > 0) {
-                // Write out the header/body separator.
-                write(CRLF_BYTES); // TODO: should this be written even for zero-length?
-                totalBytes += CRLF_BYTES.length;
                 contentBytes += copyFrom(recordInfo.getContentStream(),
                         recordInfo.getContentLength(),
                         recordInfo.getEnforceLength());


### PR DESCRIPTION
CRLF ending the WARC header is always required not only when the payload is zero.
