### PR TITLE
Java 6 compatibility

### DIFF
--- a/src/test/java/org/archive/net/PublicSuffixesTest.java
+++ b/src/test/java/org/archive/net/PublicSuffixesTest.java
@@ -36,7 +36,7 @@ import org.archive.net.PublicSuffixes.Node;
  */
 public class PublicSuffixesTest extends TestCase {
     // test of low level implementation
-    private final String NL = System.lineSeparator();
+    private final String NL = System.getProperty("line.separator");
     
     public void testCompare() {
         Node n = new Node("hoge");


### PR DESCRIPTION
System.lineSeparator() was introducted in Java 7
Pull request #26 (for issue #2) thus broke Java 6 compatibility. This restores it by using the pre 7 way of getting the system line separator. 
