### PR TITLE
Change test value to get around Java 8 bug

### DIFF
--- a/src/test/java/org/archive/util/ArchiveUtilsTest.java
+++ b/src/test/java/org/archive/util/ArchiveUtilsTest.java
@@ -229,16 +229,19 @@ public class ArchiveUtilsTest extends TestCase {
 
     /** test doubleToString() */
     public void testDoubleToString(){
-        double test = 12.345;
-        assertTrue(
+        double test = 12.121d;
+        assertEquals(
             "cecking zero precision",
-            ArchiveUtils.doubleToString(test, 0).equals("12"));
-        assertTrue(
+            "12",
+            ArchiveUtils.doubleToString(test, 0));
+        assertEquals(
             "cecking 2 character precision",
-            ArchiveUtils.doubleToString(test, 2).equals("12.34"));
-        assertTrue(
+            "12.12",
+            ArchiveUtils.doubleToString(test, 2));
+        assertEquals(
             "cecking precision higher then the double has",
-            ArchiveUtils.doubleToString(test, 65).equals("12.345"));
+            "12.121",
+            ArchiveUtils.doubleToString(test, 65));
     }
 
 


### PR DESCRIPTION
Fixes issue #31 which relates to changes in how Java rounds doubles in
some edge cases. See issue for more details.
