### PR TITLE
flush output etc before tallying stats to fix sizeOnDisk calculation

### DIFF
--- a/src/main/java/org/archive/io/warc/WARCWriter.java
+++ b/src/main/java/org/archive/io/warc/WARCWriter.java
@@ -236,8 +236,8 @@ implements WARCConstants {
         long totalBytes = 0;
         long startPosition;
 
-    	try {
-    	    startPosition = getPosition();
+        startPosition = getPosition();
+        try {
             preWriteRecordTasks();
 
             // TODO: Revisit encoding of header.
@@ -261,13 +261,12 @@ implements WARCConstants {
             write(CRLF_BYTES);
             totalBytes += 2 * CRLF_BYTES.length;
             
-            tally(recordInfo.getType(), contentBytes, totalBytes, getPosition() - startPosition);
-            
             recordInfo.setWARCFilename(getFilenameWithoutOccupiedSuffix());
             recordInfo.setWARCFileOffset(startPosition);
             tmpRecordLog.add(recordInfo);
         } finally {
             postWriteRecordTasks();
+            tally(recordInfo.getType(), contentBytes, totalBytes, getPosition() - startPosition);
         }
     }
 


### PR DESCRIPTION
There is a test that exposes the bug in this commit:
https://github.com/nlevitt/heritrix3/commit/294cfa352446f08bd94cbbc5b73d96f63535ad81
`assertEquals(warc.length(), wwp.getStats().get("totals").get("sizeOnDisk").get());`
which is currently part of this pull request:
https://github.com/internetarchive/heritrix3/pull/138/commits
(I will probably have to comment out that check until this PR is merged and a release minted)