### PR TITLE
Store origin-code in ARCRecord header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.7
+-----
+* [Store origin-code of ARC file header](https://github.com/iipc/webarchive-commons/pull/52/)
+
 1.1.6
 -----
 * [Handle empty String argument in CharsetDetector.trimAttrValue](https://github.com/iipc/webarchive-commons/pull/49)

--- a/src/main/java/org/archive/format/ArchiveFileConstants.java
+++ b/src/main/java/org/archive/format/ArchiveFileConstants.java
@@ -44,6 +44,11 @@ public interface ArchiveFileConstants {
      * Key for the Archive File version field.
      */
     public static final String VERSION_FIELD_KEY = "version";
+
+    /**
+     * Key for the Archive File origin-code field.
+     */
+    public static final String ORIGIN_FIELD_KEY = "origin";
     
     /**
      * Key for the Archive File length field.
@@ -80,7 +85,7 @@ public interface ArchiveFileConstants {
      * Key for the Archive Record absolute offset into Archive file.
      */
     public static final String ABSOLUTE_OFFSET_KEY = "absolute-offset";
-    
+
     public static final String READER_IDENTIFIER_FIELD_KEY =
     	"reader-identifier";
     

--- a/src/main/java/org/archive/format/ArchiveFileConstants.java
+++ b/src/main/java/org/archive/format/ArchiveFileConstants.java
@@ -46,7 +46,7 @@ public interface ArchiveFileConstants {
     public static final String VERSION_FIELD_KEY = "version";
 
     /**
-     * Key for the Archive File origin-code field.
+     * Key for the Archive File origin-code field. This value is often hard-coded, so use with care.
      */
     public static final String ORIGIN_FIELD_KEY = "origin";
     

--- a/src/main/java/org/archive/format/arc/ARCConstants.java
+++ b/src/main/java/org/archive/format/arc/ARCConstants.java
@@ -196,7 +196,7 @@ public interface ARCConstants extends ArchiveFileConstants {
             .asList(new String[] { URL_FIELD_KEY, IP_HEADER_FIELD_KEY,
                     DATE_FIELD_KEY, MIMETYPE_FIELD_KEY,
                     LENGTH_FIELD_KEY, VERSION_FIELD_KEY,
-                    ABSOLUTE_OFFSET_KEY });
+                    ORIGIN_FIELD_KEY, ABSOLUTE_OFFSET_KEY });
 
     /**
      * Minimum possible record length.

--- a/src/main/java/org/archive/io/arc/ARCRecord.java
+++ b/src/main/java/org/archive/io/arc/ARCRecord.java
@@ -200,7 +200,7 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
     public ARCRecord(InputStream in, final String identifier, 
                 final long offset, boolean digest,      boolean strict, 
                 final boolean parseHttpHeaders, 
-                final boolean isAlignedOnFirstRecord, String version) 
+                final boolean isAlignedOnFirstRecord, String version)
     throws IOException {
         super(in, null, 0, digest, strict);
         setHeader(parseHeaders(in, identifier, offset, strict, isAlignedOnFirstRecord, version));
@@ -243,6 +243,7 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
         getTokenizedHeaderLine(in, firstLineValues);
         
         int bodyOffset = 0;
+        String origin = "";
         if (offset == 0 && isAlignedOnFirstRecord) {
             // If offset is zero and we were aligned at first record on
             // creation (See #alignedOnFirstRecord for more on this), then no
@@ -263,6 +264,7 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
             bodyOffset += getTokenizedHeaderLine(in, secondLineValues);
             version = ((String)secondLineValues.get(0) +
                 "." + (String)secondLineValues.get(1));
+            origin = (String)secondLineValues.get(2);
             // Just read over the 3rd line.  We used to parse it and use
             // values found here but now we just hardcode them to avoid
             // having to read this 3rd line even for random arc file accesses.
@@ -271,7 +273,8 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
         }
         setBodyOffset(bodyOffset);
         
-        return computeMetaData(this.headerFieldNameKeys, firstLineValues, version, offset, identifier);
+        return computeMetaData(this.headerFieldNameKeys, firstLineValues, 
+            version, origin, offset, identifier);
     }
     
     /**
@@ -362,7 +365,8 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
      * @exception IOException  If no. of keys doesn't match no. of values.
      */
     private ARCRecordMetaData computeMetaData(List<String> keys,
-                List<String> values, String v, long offset, final String identifier)
+                List<String> values, String v, String origin,
+                long offset, final String identifier)
     throws IOException {
         if (keys.size() != values.size()) {
             List<String> originalValues = values;
@@ -423,6 +427,7 @@ public class ARCRecord extends ArchiveRecord implements ARCConstants {
         }
 
         headerFields.put(VERSION_FIELD_KEY, v);
+        headerFields.put(ORIGIN_FIELD_KEY, origin);
         headerFields.put(ABSOLUTE_OFFSET_KEY, new  Long(offset));
 
         return new ARCRecordMetaData(identifier, headerFields);

--- a/src/main/java/org/archive/io/arc/ARCRecordMetaData.java
+++ b/src/main/java/org/archive/io/arc/ARCRecordMetaData.java
@@ -169,6 +169,13 @@ public class ARCRecordMetaData implements ArchiveRecordHeader, ARCConstants {
     }
 
     /**
+     * @return Arcfile origin code.
+     */
+    public String getOrigin() {
+        return (String)this.headerFields.get(ORIGIN_FIELD_KEY);
+    }
+
+    /**
      * @return Offset into arcfile at which this record begins.
      */
     public long getOffset() {


### PR DESCRIPTION
It would be useful [for our purposes](https://github.com/lintool/warcbase/issues/199) if the origin-code from the version block of an ARC file were stored and made accessible by a method in ARCRecordMetaData. In my fork this method is called `getOrigin()`. 