### PR TITLE
Remove invalid constant

### DIFF
--- a/src/main/java/org/archive/format/warc/WARCConstants.java
+++ b/src/main/java/org/archive/format/warc/WARCConstants.java
@@ -183,8 +183,6 @@ public interface WARCConstants extends ArchiveFileConstants {
     public static final String HEADER_KEY_REFERS_TO_FILENAME = "WARC-Refers-To-Filename";
     public static final String HEADER_KEY_REFERS_TO_FILE_OFFSET = "WARC-Refers-To-File-Offset";
     
-    public static final String PROFILE_REVISIT_URI_AGNOSTIC_IDENTICAL_DIGEST = 
-            "http://netpreserve.org/warc/1.0/revisit/uri-agnostic-identical-payload-digest";
     public static final String PROFILE_REVISIT_IDENTICAL_DIGEST = 
         "http://netpreserve.org/warc/1.0/revisit/identical-payload-digest";
     public static final String PROFILE_REVISIT_NOT_MODIFIED = 


### PR DESCRIPTION
The PROFILE_REVISIT_URI_AGNOSTIC_IDENTICAL_DIGEST does not exist in the WARC specification. This file shouldn't include non-standard items. And, in any case, use of PROFILE_REVISIT_IDENTICAL_DIGEST is appropriate, even when using 'uri agnostic' deduplication.
