### PR TITLE
Make regular expression to extract URLs from CSS more restrictive

### DIFF
--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -23,7 +23,7 @@ public class ExtractingParseObserver implements ParseObserver {
 	protected static String cssUrlPatString = 
 		"url\\s*\\(\\s*((?:\\\\?[\"'])?.+?(?:\\\\?[\"'])?)\\s*\\)";
 	protected static String cssImportNoUrlPatString = 
-		"@import\\s+(('[^']+')|(\"[^\"]+\")|(\\('[^']+'\\))|(\\(\"[^\"]+\"\\))|(\\([^)]+\\))|([a-z0-9_.:/\\\\-]+))\\s*;";
+	        "@import\\s+((?:'[^']+')|(?:\"[^\"]+\")|(?:\\('[^']+'\\))|(?:\\(\"[^\"]+\"\\))|(?:\\([^)]+\\))|(?:[a-z0-9_.:/\\\\-]+))\\s*;";
 
 	protected static Pattern cssImportNoUrlPattern = Pattern
 			.compile(cssImportNoUrlPatString);
@@ -368,40 +368,45 @@ public class ExtractingParseObserver implements ParseObserver {
 			}
 		}
 	}
-	private void patternCSSExtract(HTMLMetaData data, Pattern pattern, String content) {
-		Matcher m = pattern.matcher(content);
-		int idx = 0;
-		int contentLen = content.length();
-		while((idx < contentLen) && m.find(idx)) {
-			String url = m.group(1);
-			int origUrlLength = url.length();
-			int urlStart = m.start(1);
-			int urlEnd = m.end(1);
-			idx = urlEnd;
-			if(url.length() < 2) {
-				continue;
-			}
-			if ((url.charAt(0) == '(') 
-					&& (url.charAt(origUrlLength-1) == ')')) {
-				url = url.substring(1, origUrlLength - 1);
-				urlStart += 1;
-				origUrlLength -= 2;
-			}
-			if (url.charAt(0) == '"') {
-				url = url.substring(1, origUrlLength - 1);
-				urlStart += 1;
-			} else if (url.charAt(0) == '\'') {
-				url = url.substring(1, origUrlLength - 1);
-				urlStart += 1;
-			} else if (url.charAt(0) == '\\') {
-				if(url.length() == 2)
-					continue;
-				url = url.substring(2, origUrlLength - 2);
-				urlStart += 2;
-			}
-			int urlLength = url.length();
-			data.addHref("path","STYLE/#text","href",url);
-			idx += urlLength;
-		}
-	}
+    private void patternCSSExtract(HTMLMetaData data, Pattern pattern, String content) {
+        Matcher m = pattern.matcher(content);
+        int idx = 0;
+        int contentLen = content.length();
+        if (contentLen > 100000)
+            // extract URLs only from the first 100 kB
+            contentLen = 100000;
+        FIND:
+        while((idx < contentLen) && m.find()) {
+            idx = m.end();
+            String url = m.group(1);
+            if(url.length() < 2) {
+                continue;
+            }
+            if ((url.charAt(0) == '(')
+                    && (url.charAt(url.length()-1) == ')')) {
+                url = url.substring(1, url.length() - 1);
+            }
+            CLIP:
+            while (url.length() > 1) {
+                if ((url.charAt(0) == '"' || url.charAt(0) == '\'')
+                        && (url.charAt(url.length() - 1) == '"'
+                                || url.charAt(url.length() - 1) == '\'')) {
+                    if(url.length() <= 2) {
+                        // empty URL
+                        continue FIND;
+                    }
+                    url = url.substring(1, url.length() - 1);
+                } else if (url.charAt(0) == '\\') {
+                    if(url.length() <= 4) {
+                        // empty URL
+                        continue FIND;
+                    }
+                    url = url.substring(2, url.length() - 2);
+                } else {
+                    break CLIP;
+                }
+            }
+            data.addHref("path","STYLE/#text","href",url);
+        }
+    }
 }

--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -21,7 +21,7 @@ public class ExtractingParseObserver implements ParseObserver {
 	boolean inTitle = false;
 
 	protected static String cssUrlPatString = 
-		"url\\s*\\(\\s*([\\\\\"']*.+?[\\\\\"']*)\\s*\\)";
+		"url\\s*\\(\\s*((?:\\\\?[\"'])?.+?(?:\\\\?[\"'])?)\\s*\\)";
 	protected static String cssImportNoUrlPatString = 
 		"@import\\s+(('[^']+')|(\"[^\"]+\")|(\\('[^']+'\\))|(\\(\"[^\"]+\"\\))|(\\([^)]+\\))|([a-z0-9_.:/\\\\-]+))\\s*;";
 

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -20,8 +20,8 @@ public class ExtractingParseObserverTest extends TestCase {
 				"url('\")",
 				"url(')",
 				"url('\"')",
-                "url('\\\"\"')",
-                "url(''''')"
+				"url('\\\"\"')",
+				"url(''''')"
 		};
 		boolean except = false;
 		HTMLMetaData md = new HTMLMetaData(new MetaData());
@@ -50,7 +50,8 @@ public class ExtractingParseObserverTest extends TestCase {
 				{"url(\\'foo.gif\\')","foo.gif"},
 				{"url(''foo.gif'')","foo.gif"},
 				{"url(  foo.gif  )","foo.gif"},
-				{"url('''')"}
+				{"url('''')"},
+				{"url('foo.gif'')","foo.gif"},
 				};
 		for(String[] testa : tests) {
 			checkExtract(testa);
@@ -98,7 +99,7 @@ public class ExtractingParseObserverTest extends TestCase {
 						data[i], jo.getString("href"));
 			}
 		} else {
-			assertNull(a);
+			assertNull("Expected no extracted link for <" + css + ">", a);
 		}
 	}
 	


### PR DESCRIPTION
(allow only `"`, `'`, `\"` or `\'` in front of or after the URL).
Avoid long-runners when matching the regex due to heavy back-tracking.

See commoncrawl/ia-web-commons#2 for more details.
