### PR TITLE
URLParser to strip empty port

### DIFF
--- a/src/main/java/org/archive/url/URLParser.java
+++ b/src/main/java/org/archive/url/URLParser.java
@@ -246,16 +246,20 @@ public class URLParser {
             colonPort = uriAuthority.substring(portColonIndex);
         }
         if(colonPort != null) {
-        	if(colonPort.startsWith(":")) {
-        		try {
-        			port = Integer.parseInt(colonPort.substring(1));
-        		} catch(NumberFormatException e) {
-					throw new URISyntaxException(urlString, "bad port "
-							+ colonPort.substring(1));
-				}
-        	} else {
-        		// XXX: what's happened?!
-        	}
+            if(colonPort.startsWith(":")) {
+                if (colonPort.length() == 1) {
+                    // a bare colon (http://example.com:/), use default port
+                } else {
+                    try {
+                        port = Integer.parseInt(colonPort.substring(1));
+                    } catch(NumberFormatException e) {
+                        throw new URISyntaxException(urlString, "bad port "
+                                + colonPort.substring(1));
+                    }
+                }
+            } else {
+                // XXX: what's happened?!
+            }
         }
         if(userInfo != null) {
         	int passColonIndex = userInfo.indexOf(COLON);

--- a/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
+++ b/src/test/java/org/archive/url/IAURLCanonicalizerTest.java
@@ -12,6 +12,7 @@ public class IAURLCanonicalizerTest extends TestCase {
 		compCan(iaC,"https://www.archive.org:80/","https://archive.org:80/");
 		compCan(iaC,"http://www.archive.org:443/","http://archive.org:443/");
 		compCan(iaC,"https://www.archive.org:443/","https://archive.org/");
+		compCan(iaC,"http://www.archive.org:/","http://archive.org/");
 		compCan(iaC,"http://www.archive.org/big/","http://archive.org/big");
 		compCan(iaC,"dns:www.archive.org","dns:www.archive.org");
 

--- a/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
+++ b/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
@@ -22,6 +22,7 @@ public class WaybackURLKeyMakerTest extends TestCase {
 		assertEquals("org,archive)/goo", km.makeKey("http://archive.org/goo/?"));
 		assertEquals("org,archive)/goo?a&b", km.makeKey("http://archive.org/goo/?b&a"));
 		assertEquals("org,archive)/goo?a=1&a=2&b", km.makeKey("http://archive.org/goo/?a=2&b&a=1"));
+		assertEquals("org,archive)/", km.makeKey("http://archive.org:/"));
 	}
 
 }


### PR DESCRIPTION
URLParser should strip empty an port (e.g, in `http://example.com:/`), cf. commoncrawl/ia-web-commons#5 