### PR TITLE
Improve HTML link extraction

### DIFF
--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -1,14 +1,32 @@
 package org.archive.resource.html;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.archive.extract.ExtractingResourceFactoryMapper;
+import org.archive.extract.ExtractingResourceProducer;
+import org.archive.extract.ProducerUtils;
+import org.archive.extract.ResourceFactoryMapper;
 import org.archive.resource.MetaData;
+import org.archive.resource.Resource;
+import org.archive.resource.ResourceParseException;
+import org.archive.resource.ResourceProducer;
 import org.htmlparser.nodes.TextNode;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import junit.framework.TestCase;
 
 public class ExtractingParseObserverTest extends TestCase {
+
+	private static final Logger LOG =
+			Logger.getLogger(ExtractingParseObserverTest.class.getName());
 
 	public void testHandleStyleNodeExceptions() throws Exception {
 		String[] tests = {
@@ -103,5 +121,148 @@ public class ExtractingParseObserverTest extends TestCase {
 		}
 	}
 	
+	private void checkLink(Multimap<String,String> links, String url, String path) {
+		assertTrue("Link with URL " + url + " not found", links.containsKey(url));
+		assertTrue("Wrong path " + path + " for " + url, links.get(url).contains(path));
+	}
+
+	private void checkLinks(Resource resource, String[][] expectedLinks) {
+		assertNotNull(resource);
+		assertTrue("Wrong instance type of Resource: " + resource.getClass(), resource instanceof HTMLResource);
+		MetaData md = resource.getMetaData();
+		LOG.info(md.toString());
+		Multimap<String, String> links = ArrayListMultimap.create();
+		JSONObject head = md.optJSONObject("Head");
+		if (head != null) {
+			// <base href="http://www.example.com/" />
+			String baseUrl = (String) head.opt("Base");
+			if (baseUrl != null) {
+				links.put(baseUrl, "__base__");
+			}
+			// <meta http-equiv="Refresh" content="5; URL=http://www.example.com/redirected.html" />
+			JSONArray metas = head.optJSONArray("Metas");
+			if (metas != null) {
+				for (int i = 0; i < metas.length(); i++) {
+					JSONObject o = (JSONObject) metas.optJSONObject(i);
+					String httpEquiv = o.optString("http-equiv");
+					if (httpEquiv != null && httpEquiv.equalsIgnoreCase("Refresh")) {
+						String metaRefreshTarget = o.optString("content");
+						if (metaRefreshTarget != null) {
+							metaRefreshTarget = metaRefreshTarget.replaceFirst("(?i)(?:^\\d+\\s*;)?\\s*url=", "");
+							links.put(metaRefreshTarget, "__meta_refresh__");
+						}
+					}
+				}
+			}
+		}
+		// extract outlinks
+		List<JSONArray> linkArrays = new ArrayList<JSONArray>();
+		if (md.optJSONArray("Links") != null) {
+			linkArrays.add(md.optJSONArray("Links"));
+		}
+		try {
+			if (md.getJSONObject("Head") != null && md.getJSONObject("Head").getJSONArray("Link") != null) {
+				linkArrays.add(md.getJSONObject("Head").getJSONArray("Link"));
+			}
+		} catch (JSONException e1) {
+		}
+		for (JSONArray ldata : linkArrays) {
+			for (int i = 0; i < ldata.length(); i++) {
+				JSONObject o = (JSONObject) ldata.optJSONObject(i);
+				try {
+					String url = o.getString("url");
+					links.put(url, o.getString("path"));
+					LOG.info(" found link: " + o.getString("url") + " " + o.getString("path"));
+				} catch (JSONException e) {
+					fail("Failed to extract URL from link: " + e.getMessage());
+				}
+			}
+		}
+		assertEquals("Unexpected number of links", expectedLinks.length, links.size());
+		for (String[] l : expectedLinks) {
+			checkLink(links, l[0], l[1]);
+		}
+	}
+
+	public void testLinkExtraction() throws ResourceParseException, IOException {
+		String testFileName = "link-extraction-test.warc";
+		ResourceProducer producer = ProducerUtils.getProducer(getClass().getResource(testFileName).getPath());
+		ResourceFactoryMapper mapper = new ExtractingResourceFactoryMapper();
+		ExtractingResourceProducer extractor = 
+				new ExtractingResourceProducer(producer, mapper);
+		extractor.getNext(); // skip warcinfo record
+		String[][] html4links = {
+				{"http://www.example.com/", "__base__"},
+				{"http://www.example.com/redirected.html", "__meta_refresh__"},
+				{"background.jpg", "BODY@/background"},
+				{"http://www.example.com/a-href.html", "A@/href"},
+				{"#anchor", "A@/href"},
+				{"image.png", "IMG@/src"},
+				{"image.gif", "IMG@/src"},
+				{"http://example.com/image-description.html#image.gif", "IMG@/longdesc"},
+				{"helloworld.swf", "OBJECT@/data"},
+				{"http://www.example.com/shakespeare.html", "Q@/cite"},
+				{"http://www.example.com/shakespeare-long.html", "BLOCKQUOTE@/cite"}
+		};
+		checkLinks(extractor.getNext(), html4links);
+		String[][] html5links = {
+				{"http:///www.example.com/video.html", "LINK@/href", "canonical"},
+				{"video.rss", "LINK@/href", "alternate"},
+				{"https://archive.org/download/WebmVp8Vorbis/webmvp8.gif", "VIDEO@/poster"},
+				{"https://archive.org/download/WebmVp8Vorbis/webmvp8.webm", "SOURCE@/src"},
+				{"https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4", "SOURCE@/src"},
+				{"https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv", "SOURCE@/src"}
+		};
+		checkLinks(extractor.getNext(), html5links);
+		String[][] html5links2 = {
+				{"http://www.example.com/", "A@/href"},
+		};
+		checkLinks(extractor.getNext(), html5links2);
+		String[][] fbVideoLinks = {
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "BLOCKQUOTE@/cite"},
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "A@/href"},
+				{"https://www.facebook.com/facebook/", "A@/href"},
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "DIV@/data-href"}
+		};
+		checkLinks(extractor.getNext(), fbVideoLinks);
+		String[][] dataHrefLinks = {
+				{"standard.css", "LINK@/href", "stylesheet"},
+				{"https://www.facebook.com/elegantthemes/videos/10153760379211923/", "DIV@/data-href"},
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "DIV@/data-href"},
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "BLOCKQUOTE@/cite"},
+				{"https://www.facebook.com/facebook/videos/10153231379946729/", "A@/href"},
+				{"https://www.facebook.com/facebook/", "A@/href"},
+				{"//edge.flowplayer.org/bauhaus.webm", "SOURCE@/src"},
+				{"//edge.flowplayer.org/bauhaus.mp4", "SOURCE@/src"},
+				{"//edge.flowplayer.org/functional.webm", "BUTTON@/data-href"},
+				{"/content-page", "ARTICLE@/data-href"},
+				{"/content-page",  "A@/href"},
+				{"/tags/content","A@/href"},
+				{"/tags/headlines", "A@/href"},
+				{"http://grabaperch.com", "DIV@/data-href"},
+				{"green.css", "LINK@/data-href"},
+				{"blue.css", "LINK@/data-href"},
+				{"http://codecanyon.net/user/CodingJack", "A@/data-href"},
+				{"jackbox/img/thumbs/4.jpg",  "IMG@/src"},
+				{"//venobox-destination", "A@/data-href"},
+				{"#", "A@/href"},
+				{"http://www.youtube.com/v/itTskyFLSS8&amp;rel=0&amp;autohide=1&amp;showinfo=0&amp;autoplay=1", "DIV@/data-href"},
+				{"#", "A@/href"},
+				{"http://www.youtube.com/v/itTskyFLSS8&amp;rel=0&amp;autohide=1&amp;showinfo=0", "IFRAME@/src"}
+		};
+		checkLinks(extractor.getNext(), dataHrefLinks);
+		String[][] fbSocialLinks = {
+				{"http://www.your-domain.com/your-page.html", "DIV@/data-uri"},
+				{"https://developers.facebook.com/docs/plugins/comments#configurator", "DIV@/data-href"},
+				{"https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185", "DIV@/data-href"},
+				{"https://www.facebook.com/zuck", "DIV@/data-href"},
+				{"https://developers.facebook.com/docs/plugins/", "DIV@/data-href"},
+				{"https://www.facebook.com/facebook", "DIV@/data-href"},
+				{"https://www.facebook.com/facebook", "BLOCKQUOTE@/cite"},
+				{"https://www.facebook.com/facebook", "A@/href"},
+				{"http://www.your-domain.com/your-page.html", "DIV@/data-href"}
+		};
+		checkLinks(extractor.getNext(), fbSocialLinks);
+	}
 
 }

--- a/src/test/resources/org/archive/resource/html/link-extraction-test.warc
+++ b/src/test/resources/org/archive/resource/html/link-extraction-test.warc
@@ -1,0 +1,320 @@
+WARC/1.0
+WARC-Type: warcinfo
+Content-Type: application/warc-fields
+WARC-Date: 2017-02-20T14:00:56Z
+Content-Length: 128
+
+format: WARC File Format 1.0
+conformsTo: http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf
+robots: classic
+
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Date: 2017-02-20T14:00:56Z
+WARC-Target-URI: http://www.example.com/html4.html
+Content-Type: application/http; msgtype=response
+Content-Length: 1243
+
+HTTP/1.1 200 OK
+Date: Mon, 20 Feb 2017 14:00:56 GMT
+Content-Length: 1125
+Content-Type: application/xhtml+xml
+
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Refresh" content="5; URL=http://www.example.com/redirected.html" />
+<base href="http://www.example.com/" />
+<title>Test XHTML Link Extraction</title>
+</head>
+<body background="background.jpg">
+<a href="http://www.example.com/a-href.html">A@/href</a>
+<p>
+  <a href="#anchor">anchor only</a>
+  <img src="image.png" alt="IMG@/src"/>
+  <img src="image.gif" alt="IMG@/longdesc" width="100" height="132" longdesc="http://example.com/image-description.html#image.gif">
+  <object width="400" height="400" data="helloworld.swf"><!-- https://www.w3schools.com/TAgs/tag_object.asp --></object>
+</p>
+<p>
+  <q cite="http://www.example.com/shakespeare.html">To be or not to be.</q>
+</p>
+<blockquote cite="http://www.example.com/shakespeare-long.html">
+To be, or not to be, that is the question:<br/>
+Whether 'tis nobler in the mind to suffer<br/>
+The slings and arrows of outrageous fortune, …
+</blockquote>
+</body>
+</html>
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://www.example.com/link-extraction-test-html5-video.html
+WARC-Date: 2017-02-20T21:35:03Z
+Content-Type: application/http; msgtype=response
+Content-Length: 890
+
+HTTP/1.1 200 OK
+Date: Mon, 20 Feb 2017 21:35:03 GMT
+Content-Length: 789
+Content-Type: text/html
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test HTML5 Video Tag</title>
+<meta charset="utf-8">
+<link rel="canonical" href="http:///www.example.com/video.html">
+<link rel="alternate" type="application/rss+xml" title="Videos" href="video.rss">
+</head>
+<body>
+<!-- https://developer.mozilla.org/en/docs/Web/HTML/Element/video -->
+<video width="480" controls
+  poster="https://archive.org/download/WebmVp8Vorbis/webmvp8.gif" >
+  <source
+    src="https://archive.org/download/WebmVp8Vorbis/webmvp8.webm"
+    type="video/webm">
+  <source
+    src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4"
+    type="video/mp4">
+  <source
+    src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv"
+    type="video/ogg">
+  Your browser doesn't support HTML5 video tag.
+</video>
+</body>
+</html>
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://www.example.com/poor_html5.html
+WARC-Date: 2017-02-21T15:50:40Z
+Content-Type: application/http; msgtype=response
+Content-Length: 594
+
+HTTP/1.1 200 OK
+Date: Tue, 21 Feb 2017 15:50:40 GMT
+Content-Length: 486
+Content-Type: text/html
+
+<!DOCTYPE html>
+<TitLe>Testing poor HTML5</TitLe>
+<METa CharSet="utf-8">
+<Meta name="descripTion" conTent="A bad but valid HTML5 document" />
+<META nAme="KEYWORDS" lang="de" Content="Test HTML5" />
+
+
+This is valid HTML5!
+
+<Nav>
+  <ul>
+    <lI>list item 1, hello i'm item one!
+    <li>list item 2, hello i'm item two!!
+    <lI>list item 3, hello i'm item three!
+  </UL>
+</naV>
+
+<header>header</HEADER>
+
+<h1>headline</h1>
+
+<P>paragraph one with <A hRef = http://www.example.com/ >link</a>.
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://www.example.com/fb-video.html
+WARC-Date: 2017-02-20T16:58:50Z
+Content-Type: application/http; msgtype=response
+Content-Length: 1330
+
+HTTP/1.1 200 OK
+Date: Mon, 20 Feb 2017 16:58:50 GMT
+Content-Length: 1194
+Content-Type: text/html
+
+<!-- https://developers.facebook.com/docs/plugins/embedded-video-player -->
+<html>
+<head>
+  <title>fb-video - Embedded Videos - Social Plugins</title> 
+</head>
+<body>
+
+  <!-- Load Facebook SDK for JavaScript -->
+  <div id="fb-root"></div>
+  <script>(function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));</script>
+
+  <!-- Your embedded video player code -->
+  <div class="fb-video" data-href="https://www.facebook.com/facebook/videos/10153231379946729/" data-width="500" data-show-text="false">
+    <div class="fb-xfbml-parse-ignore">
+      <blockquote cite="https://www.facebook.com/facebook/videos/10153231379946729/">
+        <a href="https://www.facebook.com/facebook/videos/10153231379946729/">How to Share With Just Friends</a>
+        <p>How to share with just friends.</p>
+        Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on Friday, December 5, 2014
+      </blockquote>
+    </div>
+  </div>
+
+</body>
+</html>
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://www.example.com/data-href.examples.html
+WARC-Date: 2017-02-21T21:05:10Z
+Content-Type: application/http; msgtype=response
+Content-Length: 3160
+
+HTTP/1.1 200 OK
+Date: Tue, 21 Feb 2017 21:05:10 GMT
+Content-Length: 3057
+Content-Type: text/html
+
+<html>
+<head>
+    <meta charset="UTF-8">
+    <!-- CSS example -->
+    <link rel="stylesheet" class="mediaquerydependent"
+        href="standard.css"
+        data-media="screen and (min-width: 600px)" data-href="green.css">
+    <link rel="stylesheet" class="mediaquerydependent"
+        data-media="screen and (min-width: 4000px)" data-href="blue.css">
+        <title></title>
+</head>
+
+
+<!-- FB embedded video player concise WP example -->
+<div class="fb-video" data-href="https://www.facebook.com/elegantthemes/videos/10153760379211923/"
+data-allowfullscreen="true" data-width="550"></div>
+
+<!-- FB embedded video player example -->
+<div class="fb-video" data-href="https://www.facebook.com/facebook/videos/10153231379946729/" data-width="500" data-show-text="false">
+    <div class="fb-xfbml-parse-ignore">
+        <blockquote cite="https://www.facebook.com/facebook/videos/10153231379946729/">
+            <a href="https://www.facebook.com/facebook/videos/10153231379946729/">How to Share With Just Friends</a>
+            <p>How to share with just friends.</p>
+            Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on Friday, December 5, 2014
+        </blockquote>
+    </div>
+</div>
+
+<!-- flowplayer example -->
+<div class="flowplayer" data-ratio="0.4167" data-debug="true">
+    <video>
+        <source type="video/webm" src="//edge.flowplayer.org/bauhaus.webm">
+        <source type="video/mp4" src="//edge.flowplayer.org/bauhaus.mp4">
+    </video>
+</div>
+<p>
+    <button id="good" data-href="//edge.flowplayer.org/functional.webm">
+    Load good URL
+    </button>
+</p>
+
+<!-- data-href jQ script example -->
+<article data-href="/content-page">
+    <h1><a href="/content-page">Headline goes here.</a></h1>
+    <p>And here goes a bit of copy about the content of the article.</p>
+    <small>Tags: <a href="/tags/content">content</a>, <a href="/tags/headlines">headlines</a></small>
+</article>
+
+<!-- FB like example -->
+<div class="fb-like" data-href="http://grabaperch.com" data-send="true" data-width="450" data-show-faces="true"></div>
+
+<!-- jackbox example -->
+<a class="jackbox"
+    data-thumbnail="jackbox/img/thumbs/num2.jpg"
+    data-group="html"
+    data-title="iFrame"
+    data-width="1100"
+    data-description="#description_1"
+    data-href="http://codecanyon.net/user/CodingJack"
+    ><!-- end opening tag -->
+    <img src="jackbox/img/thumbs/4.jpg" width="180" height="150" alt="responsive lightbox" />
+</a>
+
+<!-- venobox example: data-href takes precedence over href -->
+<a class="venobox" href="#" data-href="//venobox-destination">venobox</a>
+
+<!-- bootstrap 3 modal -->
+<div id="popup" class="modal hide fade" data-href="http://www.youtube.com/v/itTskyFLSS8&amp;rel=0&amp;autohide=1&amp;showinfo=0&amp;autoplay=1">
+    <div class="container">
+        <a href="#" class="close icon" data-dismiss="modal">X</a>
+        <iframe src="http://www.youtube.com/v/itTskyFLSS8&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="500" height="281" frameborder="0" allowfullscreen=""></iframe>
+    </div>
+</div> <!-- #popup -->
+
+
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://www.example.com/fb-social-plugins.html
+WARC-Date: 2017-02-22T09:33:02Z
+Content-Type: application/http; msgtype=response
+Content-Length: 1870
+
+HTTP/1.1 200 OK
+Date: Wed, 22 Feb 2017 09:33:02 GMT
+Content-Length: 1767
+Content-Type: text/html
+
+<!-- https://developers.facebook.com/docs/plugins/save -->
+<div class="fb-save" 
+     data-uri="http://www.your-domain.com/your-page.html">
+</div>
+
+<!-- https://developers.facebook.com/docs/plugins/comments -->
+<div class="fb-comments"
+     data-href="https://developers.facebook.com/docs/plugins/comments#configurator"
+     data-numposts="5"></div>
+
+<!-- https://developers.facebook.com/docs/plugins/embedded-comments -->
+<div class="fb-comment-embed"
+   data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185"
+   data-width="500"></div>
+
+<!-- https://developers.facebook.com/docs/plugins/follow-button -->
+<div class="fb-follow"
+     data-href="https://www.facebook.com/zuck"
+     data-layout="standard" data-size="small"
+     data-show-faces="true"></div>
+
+<!-- https://developers.facebook.com/docs/plugins/like-button -->
+<div class="fb-like"
+     data-href="https://developers.facebook.com/docs/plugins/"
+     data-layout="standard"
+     data-action="like"
+     data-size="small"
+     data-show-faces="true"
+     data-share="true"></div>
+
+<!-- https://developers.facebook.com/docs/plugins/page-plugin -->
+<div class="fb-page"
+     data-href="https://www.facebook.com/facebook"
+     data-tabs="timeline"
+     data-small-header="false"
+     data-adapt-container-width="true"
+     data-hide-cover="false"
+     data-show-facepile="true">
+  <blockquote cite="https://www.facebook.com/facebook"
+              class="fb-xfbml-parse-ignore"
+              ><a href="https://www.facebook.com/facebook">Facebook</a></blockquote></div>
+
+<!-- https://developers.facebook.com/docs/plugins/share-button -->
+  <div class="fb-share-button" 
+    data-href="http://www.your-domain.com/your-page.html" 
+    data-layout="button_count">
+  </div>
+
+


### PR DESCRIPTION
- add extractors for more elements which can take URLs as attribute values, add missing attributes, see commoncrawl/ia-web-commons#9 for details
- generalize extraction of "global" attributes (`background`)
- add custom data attributes frequently used for linking (`data-href`, `data-uri`), cf. commoncrawl/ia-web-commons#7
- extend unit tests to cover link extraction