### PR TITLE
Do not add value of preceding HTTP header field if there is no value

### DIFF
--- a/src/main/java/org/archive/format/http/HttpHeaderParser.java
+++ b/src/main/java/org/archive/format/http/HttpHeaderParser.java
@@ -301,8 +301,9 @@ public class HttpHeaderParser implements HttpConstants {
 			if(isLWSP(b)) {
 				return parser.postColonState;
 			}
+			// reset previous value also in case the header value is empty
+			parser.setValueStartIdx();
 			if(b == CR) {
-				// TODO: THINK more...
 				parser.valuePreCRState = parser.postColonState;
 				return parser.valuePostCRState;
 			}
@@ -310,7 +311,6 @@ public class HttpHeaderParser implements HttpConstants {
 				// TODO: this is lax, is LFLF an OK terminator?
 				return parser.lineStartState;
 			}
-			parser.setValueStartIdx();
 			parser.addValueByte(b);
 			return parser.valueState;
 		}

--- a/src/test/java/org/archive/format/http/HttpResponseParserTest.java
+++ b/src/test/java/org/archive/format/http/HttpResponseParserTest.java
@@ -57,4 +57,28 @@ public class HttpResponseParserTest extends TestCase {
 		
 	}
 
+	public void testParseEmptyHeaderField() throws IOException {
+
+		HttpResponseParser parser = new HttpResponseParser();
+		String message = "200 OK\r\nContent-Type: text/plain\r\nServer: \r\n\r\nHi there";
+		try {
+			HttpResponse response = 
+				parser.parse(new ByteArrayInputStream(message.getBytes(IAUtils.UTF8)));
+			assertNotNull(response);
+			HttpHeaders headers = response.getHeaders();
+			assertNotNull(headers);
+			assertEquals(2, headers.size());
+			HttpHeader header = headers.get(1);
+			assertEquals("Server",header.getName());
+			System.err.println(header.getValue());
+			assertFalse("text/plain".equals(header.getValue()));
+			TestUtils.assertStreamEquals(response, "Hi there".getBytes(IAUtils.UTF8));
+			
+		} catch (HttpParseException e) {
+			e.printStackTrace();
+			fail();
+		}
+		
+	}
+
 }


### PR DESCRIPTION
If a HTTP header field is empty (or contains only white space), the HttpHeaderParser does not use the empty value but uses the value from the preceding HTTP header field. See commoncrawl/ia-web-commons#11 for an example and test data.

This PR fixes the problem and adds a unit test.