### PR TITLE
use commons-collections v3.2.2 to avoid v3.2.1 vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
       <artifactId>guava</artifactId>
       <version>17.0</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
@@ -89,12 +89,12 @@
       <artifactId>juniversalchardet</artifactId>
       <version>1.0.3</version>
     </dependency>
-    
+
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
       <version>3.1</version>
-    </dependency>    
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -128,12 +128,12 @@
         <exclusion>
           <groupId>tomcat</groupId>
           <artifactId>jasper-compiler</artifactId>
-        </exclusion>                
+        </exclusion>
         <exclusion>
           <groupId>hsqldb</groupId>
           <artifactId>hsqldb</artifactId>
-        </exclusion>                
-      </exclusions> 
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -160,7 +160,7 @@
       <artifactId>libidn</artifactId>
       <version>1.15</version>
     </dependency>
-    <dependency>                        
+    <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>dsiutils</artifactId>
       <version>2.0.12</version>
@@ -170,13 +170,26 @@
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
         </exclusion>
+        <!-- exclude the vulnerable commons-collections v3.2.1 -->
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- explicitly require a patched commons-collections to avoid vulnerable v3.2.1 -->
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
         <version>4.3</version>
-    </dependency>                       
+    </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>


### PR DESCRIPTION
resolves #76

Dunno if it would make sense to up the version of  `it.unimi.dsi` instead, or if that would fix the vulnerability ... but do know that this should address the problems with minimal, if any, side effects.