### PR TITLE
Prevent from stackoverflow by limiting length of matched pattern

### DIFF
--- a/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
+++ b/src/main/java/org/archive/resource/html/ExtractingParseObserver.java
@@ -26,7 +26,7 @@ public class ExtractingParseObserver implements ParseObserver {
 	boolean inTitle = false;
 
 	protected static String cssUrlPatString = 
-		"url\\s*\\(\\s*((?:\\\\?[\"'])?.+?(?:\\\\?[\"'])?)\\s*\\)";
+		"url\\s*\\(\\s*([^)\\s]{1,8000}?)\\s*\\)";
 	protected static String cssUrlTrimPatString =
 			"^(?:\\\\?[\"'])+|(?:\\\\?[\"'])+$";
 	protected static String cssImportNoUrlPatString = 

--- a/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
+++ b/src/test/java/org/archive/resource/html/ExtractingParseObserverTest.java
@@ -93,6 +93,24 @@ public class ExtractingParseObserverTest extends TestCase {
 		checkExtract(test);
 	}
 
+	/**
+	 * Test whether the pattern matcher does not stack overflow with overlong
+	 * sequence of quote characters around a CSS link.
+	 */
+	public void testHandleStyleNodeNoStackOverflow() throws Exception {
+		StringBuilder sb = new StringBuilder();
+		sb.append("url(");
+		for (int i = 0; i < 20000; i++)
+			sb.append('\'');
+		sb.append("foos.gif");
+		for (int i = 0; i < 20000; i++)
+			sb.append('\'');
+		sb.append(");");
+		String[] test = new String[1];
+		test[0] = sb.toString();
+		checkExtract(test);
+	}
+
 	private void checkExtract(String[] data) throws JSONException {
 //		System.err.format("CSS(%s) want[0](%s)\n",css,want[0]);
 		String css = data[0];


### PR DESCRIPTION
The pattern used to match CSS-embedded URLs is not limited, i.e. it matches URLs of any length, potentially causing a Java stack overflow (see commoncrawl/ia-web-commons#12).

This PR fixes the issue and adds a unit test to make it reproducible resp. verify the solution.