### PR TITLE
Drop dependency on log4j 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>dsiutils</artifactId>
-      <version>2.0.12</version>
+      <version>2.2.8</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
There is a dependence on `log4j 1` via the `dsiutils` dependency.

`log4j 1` has a vulnerability ([CVE-2021-4104](https://nvd.nist.gov/vuln/detail/cve-2021-4104)) that is almost certainly not a threat with how this library uses it, but our threat monitoring software still rates it as a high severity issue and wont shut up about it.

In this PR I've updated to the newest patch level of the oldest minor version of `disutils `that drops this dependency. 2.2.8. As far as I can tell, this doesn't break anything. But given how varied our use cases are, I may well be missing something.