### PR TITLE
URLParser and WaybackURLKeyMaker fail on URLs with IPv6 address hostname

### DIFF
--- a/src/main/java/org/archive/url/URLParser.java
+++ b/src/main/java/org/archive/url/URLParser.java
@@ -226,7 +226,16 @@ public class URLParser {
         String colonPort = null;
 
         int atIndex = uriAuthority.indexOf(COMMERCIAL_AT);
-        int portColonIndex = uriAuthority.indexOf(COLON,(atIndex<0)?0:atIndex);
+        int portColonIndex = -1;
+        int startColonIndex = 0;
+        if (atIndex > -1) {
+            startColonIndex = atIndex;
+        }
+        if (uriAuthority.charAt(startColonIndex) == '[') {
+            // IPv6 address
+            startColonIndex = uriAuthority.indexOf(']', (startColonIndex + 1));
+        }
+        portColonIndex = uriAuthority.indexOf(COLON, startColonIndex);
 
         if(atIndex<0 && portColonIndex<0) {
             // most common case: neither userinfo nor port

--- a/src/main/java/org/archive/url/URLRegexTransformer.java
+++ b/src/main/java/org/archive/url/URLRegexTransformer.java
@@ -121,6 +121,10 @@ public class URLRegexTransformer {
 		// TODO: ensure we DONT reverse IP addresses!
 		String parts[] = host.split("\\.",-1);
 		if(parts.length == 1) {
+			// strip enclosing "[" and "]" from IPv6 hosts
+			if (host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']') {
+				return host.substring(1, host.length() - 1);
+			}
 			return host;
 		}
 		StringBuilder sb = new StringBuilder(host.length());

--- a/src/test/java/org/archive/url/URLParserTest.java
+++ b/src/test/java/org/archive/url/URLParserTest.java
@@ -86,6 +86,9 @@ public class URLParserTest extends TestCase {
 		checkParse(" \n http://:****@www.archive.org:8080/inde\rx.html?query#foo \r\n \t ",
 				null, "http", "", "****", "www.archive.org", 8080, "/index.html", "query", "foo",
 				"http://:****@www.archive.org:8080/index.html?query#foo", "/index.html?query");
+		checkParse("https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt", null, "https", null, null,
+				"[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]", -1, "/robots.txt", null, null,
+				"https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt", "/robots.txt");
 	}
 
 	private void checkParse(String s, String opaque, String scheme, String authUser,

--- a/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
+++ b/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
@@ -23,6 +23,9 @@ public class WaybackURLKeyMakerTest extends TestCase {
 		assertEquals("org,archive)/goo?a&b", km.makeKey("http://archive.org/goo/?b&a"));
 		assertEquals("org,archive)/goo?a=1&a=2&b", km.makeKey("http://archive.org/goo/?a=2&b&a=1"));
 		assertEquals("org,archive)/", km.makeKey("http://archive.org:/"));
+		assertEquals("192,211,203,34)/robots.txt", km.makeKey("https://34.203.211.192/robots.txt"));
+		assertEquals("2600:1f18:200d:fb00:2b74:867c:ab0c:150a)/robots.txt",
+				km.makeKey("https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt"));
 	}
 
 }


### PR DESCRIPTION
URLs/URIs with an IPv6 address as host fail to parse by URLParser. Consequently, WaybackURLKeyMaker fails to make the SURT key:

```
2024-11-26 11:07:55,243 ERROR o.c.u.WarcCdxWriter [pool-6-thread-1] Failed to make SURT for https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt: java.net.URISyntaxException: bad port 1f18:200d:fb00:2b74:867c:ab0c:150a]: https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt
        at org.archive.url.URLParser.parse(URLParser.java:257)
        at org.archive.url.WaybackURLKeyMaker.makeKey(WaybackURLKeyMaker.java:60)
        at org.commoncrawl.util.WarcCdxWriter.writeCdxLine(WarcCdxWriter.java:141)
```

This PR fixes the parser failure. Enclosing `[` and `]` are stripped from the IPv6 hosts to stay compatible with SURT keys generated by the Python [surt](https://pypi.org/project/surt/) module:
```
>>> from surt import surt
>>> surt("https://34.203.211.192/robots.txt")
'192,211,203,34)/robots.txt'
>>> surt("https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt")
'2600:1f18:200d:fb00:2b74:867c:ab0c:150a)/robots.txt'
```