### PR TITLE
SURT URL canicalization to handle non-UTF-8 percent-encoded characters

### DIFF
--- a/src/test/java/org/archive/url/BasicURLCanonicalizerTest.java
+++ b/src/test/java/org/archive/url/BasicURLCanonicalizerTest.java
@@ -143,6 +143,9 @@ public class BasicURLCanonicalizerTest extends TestCase {
 		assertEquals("%",guc.unescapeRepeatedly("%25%32%35"));
 		
 		assertEquals("168.188.99.26",guc.unescapeRepeatedly("%31%36%38%2e%31%38%38%2e%39%39%2e%32%36"));
+
+		assertEquals("tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5",
+				guc.unescapeRepeatedly("tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5"));
 	}
 	
 	public void testAttemptIPFormats() throws URIException {

--- a/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
+++ b/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
@@ -30,6 +30,8 @@ public class WaybackURLKeyMakerTest extends TestCase {
 				km.makeKey("http://1kr.ua/newslist.html?tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5"));
 		assertEquals("com,aluroba)/tags/%c3%ce%ca%c7%d1%e5%c7.htm",
 				km.makeKey("http://www.aluroba.com/tags/%C3%CE%CA%C7%D1%E5%C7.htm"));
+		assertEquals("ac,insbase)/xoops2/modules/xpwiki?%a4%d5%a4%af%a4%aa%a4%ab%b8%a9%a4%aa%a4%aa%a4%ce%a4%b8%a4%e7%a4%a6%bb%d4",
+			km.makeKey("https://www.insbase.ac/xoops2/modules/xpwiki/?%A4%D5%A4%AF%A4%AA%A4%AB%B8%A9%A4%AA%A4%AA%A4%CE%A4%B8%A4%E7%A4%A6%BB%D4"));
 	}
 
 }

--- a/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
+++ b/src/test/java/org/archive/url/WaybackURLKeyMakerTest.java
@@ -26,6 +26,10 @@ public class WaybackURLKeyMakerTest extends TestCase {
 		assertEquals("192,211,203,34)/robots.txt", km.makeKey("https://34.203.211.192/robots.txt"));
 		assertEquals("2600:1f18:200d:fb00:2b74:867c:ab0c:150a)/robots.txt",
 				km.makeKey("https://[2600:1f18:200d:fb00:2b74:867c:ab0c:150a]/robots.txt"));
+		assertEquals("ua,1kr)/newslist.html?tag=%e4%ee%f8%ea%ee%eb%fc%ed%ee%e5",
+				km.makeKey("http://1kr.ua/newslist.html?tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5"));
+		assertEquals("com,aluroba)/tags/%c3%ce%ca%c7%d1%e5%c7.htm",
+				km.makeKey("http://www.aluroba.com/tags/%C3%CE%CA%C7%D1%E5%C7.htm"));
 	}
 
 }


### PR DESCRIPTION
`WaybackURLKeyMaker.makeKey(url)` replaces percent signs by `%25` in [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) URL with bytes not representing valid utf-8 encoded characters (before [RFC 3986](https://tools.ietf.org/html/rfc3986)):

  http://www.aluroba.com/tags/%C3%CE%CA%C7%D1%E5%C7.htm
    -> com,aluroba)/tags/%25c3%25ce%25ca%25c7%25d1%25e5%25c7.htm
  https://1kr.ua/newslist.html?tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5
    -> ua,1kr)/newslist.html?tag=%25e4%25ee%25f8%25ea%25ee%25eb%25fc%25ed%25ee%25e5

Python's [surt module](https://pypi.python.org/pypi/surt) behaves different which breaks look-up in CDX files for such URLs:

```
$> pip3 show surt
Name: surt
Version: 0.3.1
Summary: Sort-friendly URI Reordering Transform (SURT) python package.
...

$> python3
>>> from surt import surt
>>> surt("http://1kr.ua/newslist.html?tag=%E4%EE%F8%EA%EE%EB%FC%ED%EE%E5")
'ua,1kr)/newslist.html?tag=%e4%ee%f8%ea%ee%eb%fc%ed%ee%e5'
>>> surt("https://www.insbase.ac/xoops2/modules/xpwiki/?%A4%D5%A4%AF%A4%AA%A4%AB%B8%A9%A4%AA%A4%AA%A4%CE%A4%B8%A4%E7%A4%A6%BB%D4")
'ac,insbase)/xoops2/modules/xpwiki?%a4%d5%a4%af%a4%aa%a4%ab%b8%a9%a4%aa%a4%aa%a4%ce%a4%b8%a4%e7%a4%a6%bb%d4'
```

Notes:
- this is a contribution of @tfmorris to CCF's fork of webarchive-commons, see commoncrawl/ia-web-commons#28, commoncrawl/ia-web-commons#6 and <https://groups.google.com/g/common-crawl/c/ek5bme_RIuM>.
- the uppercase / lowercase representation of percent encodings is not addressed in this issue
