### PR TITLE
Add RecordingInputStream.asOutputStream()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 2.0.0
 -----
 
+### New features
+
+- Added `RecordingInputStream.asOutputStream()` for direct writing of recorded data without an input stream. [#108](https://github.com/iipc/webarchive-commons/pull/108)
+
 ### Removals
 
 #### Removed Apache HttpClient 3.1

--- a/src/main/java/org/archive/io/RecordingInputStream.java
+++ b/src/main/java/org/archive/io/RecordingInputStream.java
@@ -383,12 +383,12 @@ public class RecordingInputStream
 
     @Override
     public boolean markSupported() {
-        return this.in.markSupported(); 
+        return in != null && this.in.markSupported();
     }
 
     @Override
     public synchronized void reset() throws IOException {
-        this.in.reset();
+        if (in != null) this.in.reset();
         this.recordingOutputStream.reset();
     }
 
@@ -417,5 +417,14 @@ public class RecordingInputStream
 
     public void clearForReuse() throws IOException {
         recordingOutputStream.clearForReuse();
+    }
+
+    /**
+     * Returns an OutputStream that can be used for recording input data. This is useful if the input comes in some
+     * form other than an InputStream. For example, if the input is provided by a callback periodically called with
+     * a chunk of data.
+     */
+    public RecordingOutputStream asOutputStream() {
+        return this.recordingOutputStream;
     }
 }

--- a/src/test/java/org/archive/io/RecordingInputStreamTest.java
+++ b/src/test/java/org/archive/io/RecordingInputStreamTest.java
@@ -41,7 +41,6 @@ public class RecordingInputStreamTest {
     @TempDir
     File tempDir;
 
-
     /**
      * Test readFullyOrUntil soft (no exception) and hard (exception) 
      * length cutoffs, timeout, and rate-throttling. 
@@ -127,5 +126,17 @@ public class RecordingInputStreamTest {
             }
         }.start();
         
+    }
+
+    @Test
+    public void testAsOutputStream() throws IOException {
+        RecordingInputStream ris = new RecordingInputStream(16384, (new File(
+                tempDir, "testAsOutputStream").getAbsolutePath()));
+        ris.open(null);
+        ris.asOutputStream().write("hello".getBytes());
+        ris.close();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ris.getReplayInputStream().readFullyTo(baos);
+        assertEquals("hello", baos.toString());
     }
 }


### PR DESCRIPTION
Using RecordingInputStream requires an awkward workaround when the API being recorded is not in the form of an InputStream, for example, if it's asynchronous. This adds a method to access the underlying RecordingOutputStream so you can write to it directly when that would be easier.

**Before:**
```java
byte[] inputBuffer;
InputStream ris = recorder.inputWrap(new InputStream() {
    public int read(byte[] buffer, int off, int len) {
        System.arraycopy(inputBuffer, 0, buffer, off, len);
        return len;
    }

    public int read() { throw new AssertionError(); }
});

void onDataReceived(byte[] chunk) throws IOException {
    byte[] discardBuffer = new byte[chunk.length]
    inputBuffer = chunk;
    ris.read(discardBuffer, 0, chunk.length);
}
```

**After:**
```java
InputStream ris = recorder.inputWrap(null);

void onDataReceived(byte[] chunk) throws IOException {
     ris.asOutputStream().write(chunk);
}

```