### PR TITLE
WAT extractor not to fail on metadata records without WARC-Target-URI

### DIFF
--- a/src/main/java/org/archive/extract/WATExtractorOutput.java
+++ b/src/main/java/org/archive/extract/WATExtractorOutput.java
@@ -152,6 +152,9 @@ public class WATExtractorOutput implements ExtractorOutput {
 		String targetURI;
 		if(warcType.equals("warcinfo")) {
 			targetURI = JSONUtils.extractSingle(md, "Envelope.WARC-Header-Metadata.WARC-Filename");
+		} else if (warcType.equals("metadata")) {
+			// WARC-Target-URI is optional in metadata records
+			targetURI = JSONUtils.extractSingle(md, "Envelope.Metadata-Header-Metadata.WARC-Target-URI");
 		} else {
 			targetURI = extractOrIO(md, "Envelope.WARC-Header-Metadata.WARC-Target-URI");
 		}


### PR DESCRIPTION
The WARC spec does not require a WARC-Target-URI for metadata records. The WAT extractor should not fail if a metadata record has no target URI, but simply not add one to the JSON blob.