### PR TITLE
Fix a few correctness bugs flagged by SpotBugs (static analysis)

### DIFF
--- a/src/main/java/org/archive/format/gzip/GZIPDecoder.java
+++ b/src/main/java/org/archive/format/gzip/GZIPDecoder.java
@@ -75,7 +75,7 @@ public class GZIPDecoder implements GZIPConstants {
 				// !??
 				// nope. are the next 2 possibilities?
 				if((lookahead[1] == GZIP_MAGIC_ONE) &&
-					(lookahead[2] == GZIP_MAGIC_TWO)) {
+					((lookahead[2] & 0xff) == GZIP_MAGIC_TWO)) {
 					// !12
 					keep = 2;
 				} else if(lookahead[2] == GZIP_MAGIC_ONE) {

--- a/src/main/java/org/archive/resource/MetaData.java
+++ b/src/main/java/org/archive/resource/MetaData.java
@@ -28,8 +28,8 @@ public class MetaData extends JSONObject {
 			this.topMetaData = this;
 		} else {
 			topMetaData = parentMetaData.topMetaData;
+			parentMetaData.putChild(name, this);
 		}
-		if (parentMetaData != null) parentMetaData.putChild(name, this);
 	}
 
 	public MetaData(String jsonString) throws JSONException {

--- a/src/main/java/org/archive/resource/MetaData.java
+++ b/src/main/java/org/archive/resource/MetaData.java
@@ -29,7 +29,7 @@ public class MetaData extends JSONObject {
 		} else {
 			topMetaData = parentMetaData.topMetaData;
 		}
-		parentMetaData.putChild(name, this);
+		if (parentMetaData != null) parentMetaData.putChild(name, this);
 	}
 
 	public MetaData(String jsonString) throws JSONException {

--- a/src/main/java/org/archive/util/ByteOp.java
+++ b/src/main/java/org/archive/util/ByteOp.java
@@ -237,7 +237,7 @@ public class ByteOp {
 		return drawHex(b,0,b.length,bytesPerRow);
 	}
 	public static String drawHex(byte[] b, int offset, int length, int bytesPerRow) {
-		int rows = (int) Math.ceil(length / bytesPerRow);
+		int rows = (int) Math.ceil((double) length / bytesPerRow);
 		if(rows == 0) {
 			rows = 1;
 		}

--- a/src/main/java/org/archive/util/StreamCopy.java
+++ b/src/main/java/org/archive/util/StreamCopy.java
@@ -27,7 +27,7 @@ public class StreamCopy {
 	}
 
 	public static long copyLength(InputStream i, OutputStream o, long bytes) throws IOException {
-		return copyLength(i,o,DEFAULT_READ_SIZE);
+		return copyLength(i,o,bytes,DEFAULT_READ_SIZE);
 	}
 
 	public static long copyLength(InputStream i, OutputStream o, long bytes, int readSize) throws IOException {


### PR DESCRIPTION
Ran SpotBugs over the code and a handful of CORRECTNESS warnings looked like real bugs. Small fixes below:
- StreamCopy: the 3-arg copyLength() called itself instead of the 4-arg overload, so it recurses forever. Now it delegates to the 4-arg version.
- ByteOp.drawHex: rows was Math.ceil(length / bytesPerRow), but that's integer division so ceil never rounds up. Cast to double first.
- MetaData(...): putChild() was called on parentMetaData even when it's null, which throws an NPE. Guarded the call.
- GZIPDecoder: lookahead[2] was compared to GZIP_MAGIC_TWO (0x8b) without masking, so a signed byte never matches. Added & 0xff — the same file already does this a few lines down.

Build passes locally.